### PR TITLE
feat: support forever option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {Agent} from 'https';
 import fetch, * as f from 'node-fetch';
 import {PassThrough, Readable, Duplex} from 'stream';
 import * as uuid from 'uuid';
@@ -102,6 +103,8 @@ function requestToFetchOptions(reqOpts: Options) {
   if (reqOpts.proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
     const proxy = (process.env.HTTP_PROXY || process.env.HTTPS_PROXY)!;
     options.agent = new HttpsProxyAgent(proxy);
+  } else if (reqOpts.forever) {
+    options.agent = new Agent({keepAlive: true});
   }
 
   return {uri, options};

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export interface CoreOptions {
   proxy?: string;
   multipart?: RequestPart[];
   forever?: boolean;
-  agent?: Agent;
 }
 
 export interface OptionsWithUri extends CoreOptions {

--- a/test/index.ts
+++ b/test/index.ts
@@ -100,4 +100,17 @@ describe('teeny', () => {
       done();
     });
   });
+
+  it('should accept the forever option', done => {
+    const scope = nock(uri)
+      .get('/')
+      .reply(200);
+    teenyRequest({uri, forever: true}, (err, res) => {
+      assert.ifError(err);
+      // tslint:disable-next-line no-any
+      assert.strictEqual((res.request.agent as any).keepAlive, true);
+      scope.done();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Closes #48 

So admittedly this only adds support for non-proxy users. However my goal is to resolve https://github.com/googleapis/nodejs-bigquery/issues/41, which appears to mainly affect GCF users, so I think its ok to not include proxy support?