### PR TITLE
fix: support lowercase proxy env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^10.0.0",
     "@types/node-fetch": "^2.1.2",
+    "@types/sinon": "^7.0.13",
     "@types/uuid": "^3.4.4",
     "c8": "^5.0.1",
     "codecov": "^3.1.0",
@@ -51,6 +52,7 @@
     "linkinator": "^1.5.0",
     "mocha": "^6.1.4",
     "nock": "^10.0.2",
+    "sinon": "^7.3.2",
     "typescript": "^3.0.1"
   },
   "nyc": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,8 +101,12 @@ function requestToFetchOptions(reqOpts: Options) {
     uri = uri + '?' + params;
   }
 
-  if (reqOpts.proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
-    const proxy = (process.env.HTTP_PROXY || process.env.HTTPS_PROXY)!;
+  const proxy =
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy;
+  if (reqOpts.proxy || proxy) {
     options.agent = new HttpsProxyAgent(proxy);
   } else if (reqOpts.forever) {
     options.agent = new Agent({keepAlive: true});


### PR DESCRIPTION
This came up over in https://github.com/googleapis/nodejs-storage/issues/776