### PR TITLE
fix: duplex stream does not implement methods like _read

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^10.0.0",
     "@types/node-fetch": "^2.1.2",
+    "@types/pumpify": "^1.4.1",
     "@types/sinon": "^7.0.13",
     "@types/uuid": "^3.4.4",
     "c8": "^5.0.1",
@@ -52,6 +53,7 @@
     "linkinator": "^1.5.0",
     "mocha": "^6.1.4",
     "nock": "^10.0.2",
+    "pumpify": "^2.0.0",
     "sinon": "^7.3.2",
     "typescript": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^10.0.0",
     "@types/node-fetch": "^2.1.2",
-    "@types/pumpify": "^1.4.1",
     "@types/sinon": "^7.0.13",
     "@types/uuid": "^3.4.4",
     "c8": "^5.0.1",
@@ -53,7 +52,6 @@
     "linkinator": "^1.5.0",
     "mocha": "^6.1.4",
     "nock": "^10.0.2",
-    "pumpify": "^2.0.0",
     "sinon": "^7.3.2",
     "typescript": "^3.0.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
 
 import {Agent} from 'https';
 import fetch, * as f from 'node-fetch';
-import {PassThrough, Readable, Duplex} from 'stream';
+import {PassThrough, Readable} from 'stream';
 import * as uuid from 'uuid';
 
 export interface CoreOptions {
@@ -55,7 +55,7 @@ export interface OptionsWithUrl extends CoreOptions {
 
 export type Options = OptionsWithUri | OptionsWithUrl;
 
-export interface Request extends Duplex {
+export interface Request extends PassThrough {
   agent: Agent | false;
   headers: Headers;
   href?: string;
@@ -264,7 +264,7 @@ function teenyRequest(
 
   if (callback === undefined) {
     // Stream mode
-    const requestStream = new Duplex();
+    const requestStream = new PassThrough();
     options.compress = false;
     fetch(uri, options).then(
       res => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -167,10 +167,9 @@ describe('teeny', () => {
 
   it('should emit response event when called without callback', done => {
     const scope = mockJson();
-    teenyRequest({uri})
-      .on('response', res => {
-        assert.ok(res);
-        return done();
-      })
+    teenyRequest({uri}).on('response', res => {
+      assert.ok(res);
+      return done();
+    });
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,6 +20,8 @@ import {Readable} from 'stream';
 import * as sinon from 'sinon';
 import {teenyRequest} from '../src';
 
+import * as Pumpify from 'pumpify';
+
 // tslint:disable-next-line variable-name
 const HttpsProxyAgent = require('https-proxy-agent');
 
@@ -155,5 +157,12 @@ describe('teeny', () => {
         assert.ok(res.request.agent instanceof HttpsProxyAgent);
       });
     }
+  });
+
+  // see: https://github.com/googleapis/nodejs-storage/issues/798
+  it('should not throw exception when piped through pumpify', () => {
+    const pipe = new Pumpify();
+    const scope = mockJson();
+    teenyRequest({uri}).pipe(pipe);
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -165,4 +165,12 @@ describe('teeny', () => {
     const scope = mockJson();
     teenyRequest({uri}).pipe(pipe);
   });
+
+  it('should emit response event when called without callback', done => {
+    const scope = mockJson();
+    teenyRequest({uri}).on('response', res => {
+      assert.ok(res);
+      return done();
+    });
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,7 +20,7 @@ import {Readable} from 'stream';
 import * as sinon from 'sinon';
 import {teenyRequest} from '../src';
 
-import * as Pumpify from 'pumpify';
+import {PassThrough} from 'stream';
 
 // tslint:disable-next-line variable-name
 const HttpsProxyAgent = require('https-proxy-agent');
@@ -161,16 +161,16 @@ describe('teeny', () => {
 
   // see: https://github.com/googleapis/nodejs-storage/issues/798
   it('should not throw exception when piped through pumpify', () => {
-    const pipe = new Pumpify();
     const scope = mockJson();
-    teenyRequest({uri}).pipe(pipe);
+    teenyRequest({uri}).pipe(new PassThrough());
   });
 
   it('should emit response event when called without callback', done => {
     const scope = mockJson();
-    teenyRequest({uri}).on('response', res => {
-      assert.ok(res);
-      return done();
-    });
+    teenyRequest({uri})
+      .on('response', res => {
+        assert.ok(res);
+        return done();
+      })
   });
 });


### PR DESCRIPTION
the `Duplex` stream class does not implement a variety of methods required for pipes.

see: https://github.com/googleapis/nodejs-storage/issues/798
fixes: #63