### PR TITLE
fix: undefined headers breaks compatibility with auth

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export class RequestError extends Error {
 }
 
 interface Headers {
-  [index: string]: string | undefined;
+  [index: string]: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,8 @@ export class RequestError extends Error {
 }
 
 interface Headers {
-  [index: string]: string;
+  // tslint:disable-next-line no-any
+  [index: string]: any;
 }
 
 /**


### PR DESCRIPTION
allowing an `undefined` value for header values breaks compatibility with`google-auth-library-nodejs`:

```bash
                                 ~~~~~~~~~~~~~~~~~

test/test.jwt.ts:273:19 - error TS2532: Object is possibly 'undefined'.

273   const decoded = got.Authorization.replace('Bearer ', '');
                      ~~~~~~~~~~~~~~~~~

test/test.jwtaccess.ts:61:30 - error TS2532: Object is possibly 'undefined'.

61   const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
                                ~~~~~~~~~~~~~~~~~~~~~

test/test.jwtaccess.ts:72:30 - error TS2532: Object is possibly 'undefined'.

72   const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
``` 

Unless we have a pressing need to set undefined headers, I recommend we revert this change for the time being.