### PR TITLE
fix: if scheme is http:// use an HTTP agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/googleapis/teeny-request#readme",
   "dependencies": {
+    "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "node-fetch": "^2.2.0",
     "stream-events": "^1.0.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ function requestToFetchOptions(reqOpts: Options) {
     uri = uri + '?' + params;
   }
 
+  const isHttp = /^http:\/\//.test(uri);
   const proxy =
     reqOpts.proxy ||
     process.env.HTTP_PROXY ||
@@ -141,11 +142,11 @@ function requestToFetchOptions(reqOpts: Options) {
     process.env.HTTPS_PROXY ||
     process.env.https_proxy;
   if (proxy) {
-    options.agent = /^http:\/\//.test(uri)
+    options.agent = isHttp
       ? new HttpProxyAgent(proxy)
       : new HttpsProxyAgent(proxy);
   } else if (reqOpts.forever) {
-    options.agent = /^http:\/\//.test(uri)
+    options.agent = isHttp
       ? new HTTPAgent({keepAlive: true})
       : new Agent({keepAlive: true});
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,8 @@ export interface RequestCallback<T = any> {
 }
 
 // tslint:disable-next-line variable-name
+const HttpProxyAgent = require('http-proxy-agent');
+// tslint:disable-next-line variable-name
 const HttpsProxyAgent = require('https-proxy-agent');
 
 export class RequestError extends Error {
@@ -136,10 +138,12 @@ function requestToFetchOptions(reqOpts: Options) {
     process.env.HTTP_PROXY ||
     process.env.http_proxy ||
     process.env.HTTPS_PROXY ||
-    process.env.https_proxy;
-  if (reqOpts.proxy || proxy) {
-    // TODO: we should support an HTTP proxy.
-    options.agent = new HttpsProxyAgent(proxy);
+    process.env.https_proxy ||
+    reqOpts.proxy;
+  if (proxy) {
+    options.agent = /^http:\/\//.test(uri)
+      ? new HttpProxyAgent(proxy)
+      : new HttpsProxyAgent(proxy);
   } else if (reqOpts.forever) {
     options.agent = /^http:\/\//.test(uri)
       ? new HTTPAgent({keepAlive: true})

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import {Agent as HTTPAgent} from 'http';
 import {Agent} from 'https';
+
 import fetch, * as f from 'node-fetch';
 import {PassThrough, Readable} from 'stream';
 import * as uuid from 'uuid';
@@ -136,9 +138,12 @@ function requestToFetchOptions(reqOpts: Options) {
     process.env.HTTPS_PROXY ||
     process.env.https_proxy;
   if (reqOpts.proxy || proxy) {
+    // TODO: we should support an HTTP proxy.
     options.agent = new HttpsProxyAgent(proxy);
   } else if (reqOpts.forever) {
-    options.agent = new Agent({keepAlive: true});
+    options.agent = /^http:\/\//.test(uri)
+      ? new HTTPAgent({keepAlive: true})
+      : new Agent({keepAlive: true});
   }
 
   return {uri, options};

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,11 @@ function requestToFetchOptions(reqOpts: Options) {
   }
 
   const proxy =
+    reqOpts.proxy ||
     process.env.HTTP_PROXY ||
     process.env.http_proxy ||
     process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    reqOpts.proxy;
+    process.env.https_proxy;
   if (proxy) {
     options.agent = /^http:\/\//.test(uri)
       ? new HttpProxyAgent(proxy)

--- a/test/index.ts
+++ b/test/index.ts
@@ -26,7 +26,7 @@ import {PassThrough} from 'stream';
 const HttpsProxyAgent = require('https-proxy-agent');
 
 nock.disableNetConnect();
-const uri = 'http://example.com';
+const uri = 'https://example.com';
 
 function mockJson() {
   return nock(uri)
@@ -142,22 +142,23 @@ describe('teeny', () => {
     });
   });
 
-  it('should respect environment variables for proxy config', () => {
-    const envVars = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'];
-    for (const v of envVars) {
+  const envVars = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'];
+  for (const v of envVars) {
+    it('should respect environment variables for proxy config', done => {
       sandbox.stub(process, 'env').value({[v]: 'https://fake.proxy'});
       const expectedBody = {hello: '🌎'};
       const scope = nock(uri)
         .get('/')
         .reply(200, expectedBody);
       teenyRequest({uri}, (err, res, body) => {
-        assert.ifError(err);
         scope.done();
+        assert.ifError(err);
         assert.deepStrictEqual(expectedBody, body);
         assert.ok(res.request.agent instanceof HttpsProxyAgent);
+        return done();
       });
-    }
-  });
+    });
+  }
 
   // see: https://github.com/googleapis/nodejs-storage/issues/798
   it('should not throw exception when piped through pumpify', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -144,7 +144,7 @@ describe('teeny', () => {
 
   const envVars = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'];
   for (const v of envVars) {
-    it('should respect environment variables for proxy config', done => {
+    it(`should respect ${v} environment variable for proxy config`, done => {
       sandbox.stub(process, 'env').value({[v]: 'https://fake.proxy'});
       const expectedBody = {hello: '🌎'};
       const scope = nock(uri)
@@ -159,6 +159,20 @@ describe('teeny', () => {
       });
     });
   }
+
+  it('should use proxy if set in request options', done => {
+    const expectedBody = {hello: '🌎'};
+    const scope = nock(uri)
+      .get('/')
+      .reply(200, expectedBody);
+    teenyRequest({uri, proxy: 'https://fake.proxy'}, (err, res, body) => {
+      scope.done();
+      assert.ifError(err);
+      assert.deepStrictEqual(expectedBody, body);
+      assert.ok(res.request.agent instanceof HttpsProxyAgent);
+      return done();
+    });
+  });
 
   // see: https://github.com/googleapis/nodejs-storage/issues/798
   it('should not throw exception when piped through pumpify', () => {


### PR DESCRIPTION
we were always creating an `https.Agent`, even though we accept an `http://` scheme.