### PR TITLE
fix(types): make types less strict for method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,17 +23,7 @@ import * as uuid from 'uuid';
 const streamEvents = require('stream-events');
 
 export interface CoreOptions {
-  method?:
-    | 'GET'
-    | 'POST'
-    | 'PUT'
-    | 'HEAD'
-    | 'OPTIONS'
-    | 'PATCH'
-    | 'DELETE'
-    | 'CONNECT'
-    | 'OPTIONS'
-    | 'TRACE';
+  method?: string;
   timeout?: number;
   gzip?: boolean;
   // tslint:disable-next-line no-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Google LLC. All Rights Reserved.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
we're getting bitten in a variety of upstream libraries that rely on passing a string to `method` rather than the stricter `enum`.

Let's loosen the type.