### PR TITLE
fix!: remove console log and throw instead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,8 @@ function teenyRequest(
   const multipart = reqOpts.multipart as RequestPart[];
   if (reqOpts.multipart && multipart.length === 2) {
     if (!callback) {
-      throw new Error('multipart without callback not implemented.');
+      // TODO: add support for multipart uploads through streaming
+      throw new Error('Multipart without callback is not implemented.');
     }
     const boundary: string = uuid.v4();
     (options.headers as Headers)[

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,7 @@ function teenyRequest(
   const multipart = reqOpts.multipart as RequestPart[];
   if (reqOpts.multipart && multipart.length === 2) {
     if (!callback) {
-      console.error('multipart without callback not implemented.');
-      return;
+      throw new Error('multipart without callback not implemented.');
     }
     const boundary: string = uuid.v4();
     (options.headers as Headers)[


### PR DESCRIPTION
BREAKING CHANGE: In previous releases of the library, invoking the `request` with a multipart upload, and no defined callback (consuming a stream) would result in unpredictable behavior.  The code would write to console, but the method would just return.  To make the behavior more explicit, the method will now throw if multipart uploads and no callback are provided. 

Fixes #70 