### PR TITLE
feat: pass agent options when using agent pool config

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -19,9 +19,6 @@ import {Agent as HTTPSAgent} from 'https';
 import {parse} from 'url';
 import {Options} from './';
 
-const createHttpProxyAgent = require('http-proxy-agent');
-const createHttpsProxyAgent = require('https-proxy-agent');
-
 export const pool = new Map<string, HTTPAgent>();
 
 export type HttpAnyAgent = HTTPAgent | HTTPSAgent;
@@ -50,7 +47,9 @@ export function getAgent(
 
   if (proxy) {
     // tslint:disable-next-line variable-name
-    const Agent = isHttp ? createHttpProxyAgent : createHttpsProxyAgent;
+    const Agent = isHttp
+      ? require('http-proxy-agent')
+      : require('https-proxy-agent');
 
     const proxyOpts = {...parse(proxy), ...poolOptions};
     return new Agent(proxyOpts);

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -16,19 +16,28 @@
 
 import {Agent as HTTPAgent} from 'http';
 import {Agent as HTTPSAgent} from 'https';
+import {parse} from 'url';
 import {Options} from './';
 
-const pool = new Map<string, HTTPAgent>();
+const createHttpProxyAgent = require('http-proxy-agent');
+const createHttpsProxyAgent = require('https-proxy-agent');
+
+export const pool = new Map<string, HTTPAgent>();
+
+export type HttpAnyAgent = HTTPAgent | HTTPSAgent;
 
 /**
  * Returns a custom request Agent if one is found, otherwise returns undefined
  * which will result in the global http(s) Agent being used.
  * @private
  * @param {string} uri The request uri
- * @param {object} reqOpts The request options
- * @returns {Agent|undefined}
+ * @param {Options} reqOpts The request options
+ * @returns {HttpAnyAgent|undefined}
  */
-export function getAgent(uri: string, reqOpts: Options): HTTPAgent | undefined {
+export function getAgent(
+  uri: string,
+  reqOpts: Options
+): HttpAnyAgent | undefined {
   const isHttp = uri.startsWith('http://');
   const proxy =
     reqOpts.proxy ||
@@ -37,13 +46,14 @@ export function getAgent(uri: string, reqOpts: Options): HTTPAgent | undefined {
     process.env.HTTPS_PROXY ||
     process.env.https_proxy;
 
+  const poolOptions = Object.assign({}, reqOpts.pool);
+
   if (proxy) {
     // tslint:disable-next-line variable-name
-    const Agent = isHttp
-      ? require('http-proxy-agent')
-      : require('https-proxy-agent');
+    const Agent = isHttp ? createHttpProxyAgent : createHttpsProxyAgent;
 
-    return new Agent(proxy) as HTTPAgent;
+    const proxyOpts = {...parse(proxy), ...poolOptions};
+    return new Agent(proxyOpts);
   }
 
   let key = isHttp ? 'http' : 'https';
@@ -54,7 +64,7 @@ export function getAgent(uri: string, reqOpts: Options): HTTPAgent | undefined {
     if (!pool.has(key)) {
       // tslint:disable-next-line variable-name
       const Agent = isHttp ? HTTPAgent : HTTPSAgent;
-      pool.set(key, new Agent({keepAlive: true}));
+      pool.set(key, new Agent({...poolOptions, keepAlive: true}));
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {Agent} from 'https';
+import {Agent, AgentOptions as HttpsAgentOptions} from 'https';
+import {AgentOptions as HttpAgentOptions} from 'http';
 import fetch, * as f from 'node-fetch';
 import {PassThrough, Readable} from 'stream';
 import * as uuid from 'uuid';
@@ -35,6 +36,7 @@ export interface CoreOptions {
   proxy?: string;
   multipart?: RequestPart[];
   forever?: boolean;
+  pool?: HttpsAgentOptions | HttpAgentOptions;
 }
 
 export interface OptionsWithUri extends CoreOptions {

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,6 +20,7 @@ import * as nock from 'nock';
 import {Readable, PassThrough} from 'stream';
 import * as sinon from 'sinon';
 import {teenyRequest} from '../src';
+import {pool} from '../src/agents';
 
 // tslint:disable-next-line variable-name
 const HttpProxyAgent = require('http-proxy-agent');
@@ -38,6 +39,7 @@ function mockJson() {
 describe('teeny', () => {
   const sandbox = sinon.createSandbox();
   afterEach(() => {
+    pool.clear();
     sandbox.restore();
     nock.cleanAll();
   });


### PR DESCRIPTION
1. Defines the `pool` as used in `@google-cloud/common`: https://github.com/googleapis/nodejs-common/blob/v3.0.0/src/util.ts#L37-L40
2. All properties optionally defined in `pool` are passed through to the underlying agent, _only_ if the agent is to be created
3. `pool` is now a "protected" member, only to make test cases possible given the singleton~ish variable bleed
4. fixed `forever` tests that were supposed to test `https`, but actually were testing `http`
5. enhanced existing agent tests to ensure the proxy data was actually picked up by the agent

- [X] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #148  🦕
