### PR TITLE
fix: support uri optionless overload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,12 +186,39 @@ function createMultipartStream(boundary: string, multipart: RequestPart[]) {
   return stream;
 }
 
+function teenyRequest(url: string): Request;
+function teenyRequest(url: string, reqOpts: Options): Request;
+function teenyRequest(url: string, callback: RequestCallback): void;
+function teenyRequest(
+  url: string,
+  reqOpts: Options,
+  callback: RequestCallback
+): void;
 function teenyRequest(reqOpts: Options): Request;
 function teenyRequest(reqOpts: Options, callback: RequestCallback): void;
 function teenyRequest(
-  reqOpts: Options,
-  callback?: RequestCallback
+  urlOrOpts: Options | string,
+  optsOrCallback?: Options | RequestCallback,
+  cb?: RequestCallback
 ): Request | void {
+  let url: string | undefined = undefined;
+  let reqOpts: Options | undefined = undefined;
+  if (typeof urlOrOpts === 'string') {
+    url = urlOrOpts;
+  }
+  if (typeof urlOrOpts === 'object') {
+    reqOpts = urlOrOpts;
+  }
+  if (typeof optsOrCallback === 'object') {
+    reqOpts = optsOrCallback;
+  }
+  const callback = typeof optsOrCallback === 'function' ? optsOrCallback : cb;
+  reqOpts = reqOpts || {url: url!};
+  if (url) {
+    (reqOpts as OptionsWithUrl).url = url;
+    (reqOpts as OptionsWithUri).uri = url;
+  }
+
   const {uri, options} = requestToFetchOptions(reqOpts);
 
   const multipart = reqOpts.multipart as RequestPart[];

--- a/test/index.ts
+++ b/test/index.ts
@@ -272,6 +272,17 @@ describe('teeny', () => {
     });
   });
 
+  it('should support passing url independent of options', done => {
+    const scope = mockJson();
+    teenyRequest(uri, (error, response, body) => {
+      assert.ifError(error);
+      assert.strictEqual(response.statusCode, 200);
+      assert.ok(body.hello);
+      scope.done();
+      done();
+    });
+  });
+
   it('should expose TeenyStatistics instance', () => {
     assert.ok(teenyRequest.stats instanceof TeenyStatistics);
   });


### PR DESCRIPTION
Working in another codebase, I noticed that teeny didn't support the request function in the form of:

```js
request('https://www.google.com').pipe(res);
```

So I added overloads to take the naked url param into account.  