### PR TITLE
feat: add support for followRedirect option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export interface CoreOptions {
   multipart?: RequestPart[];
   forever?: boolean;
   pool?: HttpsAgentOptions | HttpAgentOptions;
+  followRedirect?: boolean;
 }
 
 export interface OptionsWithUri extends CoreOptions {
@@ -124,6 +125,9 @@ function requestToFetchOptions(reqOpts: Options) {
   }
 
   options.agent = getAgent(uri, reqOpts);
+  if (reqOpts.followRedirect === false) {
+    options.redirect = 'manual';
+  }
 
   return {uri, options};
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -389,4 +389,22 @@ describe('teeny', () => {
       }
     );
   });
+
+  it('should respect followRedirect option being disabled', done => {
+    const scope = nock(uri).get('/').reply(302, '', {
+      location: 'https://www.google.com',
+    });
+    teenyRequest(
+      {
+        uri,
+        followRedirect: false,
+      },
+      (err, res) => {
+        assert.ifError(err);
+        assert.strictEqual(res.statusCode, 302);
+        scope.done();
+        done();
+      }
+    );
+  });
 });


### PR DESCRIPTION
This is pretty lightweight, and came up while trying to help firebase-tools get off of request.