### PR TITLE
chore: adds @license JSDoc tag to license comments

### DIFF
--- a/src/TeenyStatistics.ts
+++ b/src/TeenyStatistics.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TeenyStatistics.ts
+++ b/test/TeenyStatistics.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/agents.ts
+++ b/test/agents.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright 2018 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION

Hi, this change just formats the license blocks to play a bit better when importing into Google3.

I've opened a few other PRs like this one already, as an FYI: https://github.com/googleapis/nodejs-common/pull/645

Let me know if this looks ok or if you need anymore context.

Thanks!