### PR TITLE
fix (getAgent): add nullish check for uri

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,11 @@ function requestToFetchOptions(reqOpts: Options) {
 
   let uri = ((reqOpts as OptionsWithUri).uri ||
     (reqOpts as OptionsWithUrl).url) as string;
+
+  if (!uri) {
+    throw new Error('Missing uri or url in reqOpts.');
+  }
+
   if (reqOpts.useQuerystring === true || typeof reqOpts.qs === 'object') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const qs = require('querystring');

--- a/test/index.ts
+++ b/test/index.ts
@@ -435,4 +435,26 @@ describe('teeny', () => {
       }
     );
   });
+
+  it('should throw an exception if uri is an empty string', done => {
+    assert.throws(
+      () => {
+        teenyRequest({uri: ''});
+      },
+      /Missing uri or url in reqOpts/,
+      'Did not throw with expected message'
+    );
+    done();
+  });
+
+  it('should throw an exception if url is an empty string', done => {
+    assert.throws(
+      () => {
+        teenyRequest({url: ''});
+      },
+      /Missing uri or url in reqOpts/,
+      'Did not throw with expected message'
+    );
+    done();
+  });
 });


### PR DESCRIPTION
This adds a fix to `requestToFetchOptions` to throw an exception if `uri` is missing when calling from `teenyRequest`.

We should do this because we can't guarantee that the value is always a string
(due to type assertions) or code calling it without a valid string.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #236 🦕
