### PR TITLE
Drop uuid package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.1",
-    "stream-events": "^1.0.5",
-    "uuid": "^8.0.0"
+    "stream-events": "^1.0.5"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {Agent, AgentOptions as HttpsAgentOptions} from 'https';
 import {AgentOptions as HttpAgentOptions} from 'http';
 import fetch, * as f from 'node-fetch';
 import {PassThrough, Readable} from 'stream';
-import * as uuid from 'uuid';
+import {randomUUID} from 'crypto';
 import {getAgent} from './agents';
 import {TeenyStatistics} from './TeenyStatistics';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -208,7 +208,7 @@ function teenyRequest(
       // TODO: add support for multipart uploads through streaming
       throw new Error('Multipart without callback is not implemented.');
     }
-    const boundary: string = uuid.v4();
+    const boundary: string = randomUUID();
     (options.headers as Headers)[
       'Content-Type'
     ] = `multipart/related; boundary=${boundary}`;


### PR DESCRIPTION
This PR drops the uuid package from project dependencies and substitutes it with the crypto module from Node.js.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
