### PR TITLE
chore(deps): use randomUUID from Node.js runtime, not from uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.9",
-    "stream-events": "^1.0.5",
-    "uuid": "^9.0.0"
+    "stream-events": "^1.0.5"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",
@@ -50,7 +49,6 @@
     "@types/mocha": "^10.0.0",
     "@types/node-fetch": "^2.5.7",
     "@types/sinon": "^17.0.0",
-    "@types/uuid": "^9.0.0",
     "c8": "^9.0.0",
     "codecov": "^3.1.0",
     "gts": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {Agent, AgentOptions as HttpsAgentOptions} from 'https';
 import {AgentOptions as HttpAgentOptions} from 'http';
 import fetch, * as f from 'node-fetch';
 import {PassThrough, Readable, pipeline} from 'stream';
-import * as uuid from 'uuid';
+import {randomUUID} from 'crypto'
 import {getAgent} from './agents';
 import {TeenyStatistics} from './TeenyStatistics';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -208,7 +208,7 @@ function teenyRequest(
       // TODO: add support for multipart uploads through streaming
       throw new Error('Multipart without callback is not implemented.');
     }
-    const boundary: string = uuid.v4();
+    const boundary: string = randomUUID();
     (options.headers as Headers)[
       'Content-Type'
     ] = `multipart/related; boundary=${boundary}`;


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕


### Changes to be introduced: 
This is not bug fix or feature enhancement. 

This PR removes `uuid` library from the repo, since Node.js provides randomUUID function from Node.js v15.6.0, v14.17.0. 
https://nodejs.org/api/crypto.html#cryptorandomuuidoptions

