### PR TITLE
feat: support fetch Headers class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,11 @@ function requestToFetchOptions(reqOpts: Options) {
   if (typeof reqOpts.json === 'object') {
     // Add Content-type: application/json header
     reqOpts.headers = reqOpts.headers || {};
-    reqOpts.headers['Content-Type'] = 'application/json';
+    if (reqOpts.headers instanceof globalThis.Headers) {
+      reqOpts.headers.set('Content-Type', 'application/json');
+    } else {
+      reqOpts.headers['Content-Type'] = 'application/json';
+    }
 
     // Set body to JSON representation of value
     options.body = JSON.stringify(reqOpts.json);
@@ -119,8 +123,15 @@ function requestToFetchOptions(reqOpts: Options) {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  options.headers = reqOpts.headers as any;
+  if (reqOpts.headers instanceof globalThis.Headers) {
+    options.headers = {};
+    for (const pair of reqOpts.headers.entries()) {
+      options.headers[pair[0]] = pair[1];
+    }
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options.headers = reqOpts.headers as any;
+  }
 
   let uri = ((reqOpts as OptionsWithUri).uri ||
     (reqOpts as OptionsWithUrl).url) as string;

--- a/test/index.ts
+++ b/test/index.ts
@@ -156,7 +156,6 @@ describe('teeny', () => {
     headers.set('dinner', 'pizza');
     teenyRequest({uri, headers, json: body, method: 'POST'}, (err, res) => {
       assert.ifError(err);
-      console.log('headers', res.headers);
       assert.strictEqual(res.headers['country'], 'Italy');
       assert.strictEqual(res.headers['content-type'], 'application/json');
       scope.done();

--- a/test/index.ts
+++ b/test/index.ts
@@ -144,7 +144,7 @@ describe('teeny', () => {
     });
   });
 
-  it.only('should accept fetch Headers', done => {
+  it('should accept fetch Headers', done => {
     const body = {dish: '🍕'};
     const scope = nock(uri)
       .post('/')

--- a/test/index.ts
+++ b/test/index.ts
@@ -144,6 +144,26 @@ describe('teeny', () => {
     });
   });
 
+  it.only('should accept fetch Headers', done => {
+    const body = {dish: '🍕'};
+    const scope = nock(uri)
+      .post('/')
+      .matchHeader('dinner', 'pizza')
+      .matchHeader('content-type', 'application/json')
+      .reply(200, body, {country: 'Italy'});
+
+    const headers = new Headers();
+    headers.set('dinner', 'pizza');
+    teenyRequest({uri, headers, json: body, method: 'POST'}, (err, res) => {
+      assert.ifError(err);
+      console.log('headers', res.headers);
+      assert.strictEqual(res.headers['country'], 'Italy');
+      assert.strictEqual(res.headers['content-type'], 'application/json');
+      scope.done();
+      done();
+    });
+  });
+
   it('should accept the forever option', async () => {
     const scope = nock(uri).get('/').reply(200);
     teenyRequest({uri, forever: true}, (err, res) => {


### PR DESCRIPTION
With new changes on google auth library (v10), headers can come as [Fetch Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers), which is not supported by Teeny Request. Due to this mismatch,  usage of the  new auth lib causes system tests on Node BigQuery to fail (see https://github.com/googleapis/nodejs-bigquery/pull/1458)

`CoreOptions.headers` was not updated as it would cause a breaking change and require consumers of the library to check if headers are an object vs Fetch Header. This change make it backward compatible.

Towards https://github.com/googleapis/nodejs-bigquery/pull/1458
